### PR TITLE
Support for Redmine5 (#156)

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,6 +1,6 @@
 require 'redmine'
 
-require_dependency 'redmine_slack/listener'
+require File.expand_path('../lib/redmine_slack/listener', __FILE__)
 
 Redmine::Plugin.register :redmine_slack do
 	name 'Redmine Slack'
@@ -23,9 +23,17 @@ Redmine::Plugin.register :redmine_slack do
 		:partial => 'settings/slack_settings'
 end
 
-((Rails.version > "5")? ActiveSupport::Reloader : ActionDispatch::Callbacks).to_prepare do
-	require_dependency 'issue'
-	unless Issue.included_modules.include? RedmineSlack::IssuePatch
-		Issue.send(:include, RedmineSlack::IssuePatch)
+if Rails.version > '6.0' && Rails.autoloaders.zeitwerk_enabled?
+	Rails.application.config.after_initialize do
+		unless Issue.included_modules.include? RedmineSlack::IssuePatch
+			Issue.send(:include, RedmineSlack::IssuePatch)
+		end
+	end
+else
+	((Rails.version > "5")? ActiveSupport::Reloader : ActionDispatch::Callbacks).to_prepare do
+		require_dependency 'issue'
+		unless Issue.included_modules.include? RedmineSlack::IssuePatch
+			Issue.send(:include, RedmineSlack::IssuePatch)
+		end
 	end
 end

--- a/lib/redmine_slack/listener.rb
+++ b/lib/redmine_slack/listener.rb
@@ -1,6 +1,7 @@
 require 'httpclient'
 
-class SlackListener < Redmine::Hook::Listener
+module RedmineSlack
+class Listener < Redmine::Hook::Listener
 	def redmine_slack_issues_new_after_save(context={})
 		issue = context[:issue]
 
@@ -291,4 +292,5 @@ private
 		# dashes and underscores and must start with a letter or number.
 		text.scan(/@[a-z0-9][a-z0-9_\-]*/).uniq
 	end
+end
 end


### PR DESCRIPTION
Please merge the following improved by sciyoshi-san.

---

* replace require_dependency with require

* Support for Zeitwerk/Rails6

- rename SlackListener to RedmineSlack::Listener
- replace ActiveSupport::Reloader.to_prepare with Rails.application.config.after_initialize