### PR TITLE
Improvement of 'certificate verify failed' error

### DIFF
--- a/lib/redmine_slack/listener.rb
+++ b/lib/redmine_slack/listener.rb
@@ -163,7 +163,7 @@ class Listener < Redmine::Hook::Listener
 
 		begin
 			client = HTTPClient.new
-			client.ssl_config.cert_store.set_default_paths
+			client.ssl_config.add_trust_ca(OpenSSL::X509::DEFAULT_CERT_FILE)
 			client.ssl_config.ssl_version = :auto
 			client.post_async url, :body => params.to_json, :header => headers
 		rescue Exception => e


### PR DESCRIPTION
I made some corrections to fix the issue of "SSL_connect returned=1 errno=0 state=error: certificate verify failed (certificate has expired)" that has been occurring for a few weeks now.

@scotto1973, thank you for your reports and for sharing the solution.

Related: https://github.com/sciyoshi/redmine-slack/issues/157